### PR TITLE
Avoid listing invisible files beginning with ~. MODULE - QC.R

### DIFF
--- a/QC tool/deps/MODULE - QC.R
+++ b/QC tool/deps/MODULE - QC.R
@@ -125,7 +125,7 @@ Server_QcViewerMod <- function(id, appWd){
       
       InputXlsx_reactVals$FileNames <- 
            list.files(FilePath_InputDataFolder_react(),
-                      pattern = "^.+\\..+$")
+                      pattern = "^[^~].+\\..+$")
       
       InputXlsx_reactVals$FileNames
       })


### PR DESCRIPTION
This caused issues with reading excel files in the Input folder.